### PR TITLE
Add curve stroking

### DIFF
--- a/resources/config_files/myconfig_DEFAULTS.yml
+++ b/resources/config_files/myconfig_DEFAULTS.yml
@@ -38,3 +38,4 @@ options:
   radius_vertex_elevation: 1.0
   threshold_jump_edges: 0.5
   threshold_bridge_jump_edges: 0.5
+  max_angle_curvepolygon: 0.0

--- a/resources/config_files/myconfig_README.yml
+++ b/resources/config_files/myconfig_README.yml
@@ -91,4 +91,5 @@ options:                                                # Global options
   radius_vertex_elevation: 1.0                          # Radius in meters used for point-vertex distance between 3D points and vertices of polygons
   threshold_jump_edges: 0.5                             # Threshold in meters for stitching adjacent objects, when the height difference is larger then the threshold a vertical wall is created 
   threshold_bridge_jump_edges: 0.5                      # Threshold in meters for stitching bridges to adjacent objects, if not specified it falls back to threshold_jump_edges
+  max_angle_curvepolygon: 0.0                           # The largest allowed step in degrees along the arc of a curved polygon. Value for dfMaxAngleStepSizeDegrees passed to OGR CurvePolyToPoly(), zero to use the default setting. 
   extent: xmin, ymin, xmax, ymax                        # Filter the input polygons to this extent

--- a/src/Map3d.cpp
+++ b/src/Map3d.cpp
@@ -1039,7 +1039,12 @@ bool Map3d::extract_and_add_polygon(GDALDataset* dataSource, PolygonFile* file) 
       std::clog << "\tSplit " << numSplitMulti << " MultiPolygon(s) into " << numSplitPoly << " Polygon(s)\n";
     }
     if (numCurvePoly > 0) {
-      std::clog << "\tStroked " << numCurvePoly << " CurvePolygon(s) with a maximum angle of " << _max_angle_curvepolygon << "\n";
+      if (_max_angle_curvepolygon == 0.0) {
+        std::clog << "\tStroked " << numCurvePoly << " CurvePolygon(s) with a maximum angle of 4.0 degrees (default value)\n";
+      }
+      else {
+        std::clog << "\tStroked " << numCurvePoly << " CurvePolygon(s) with a maximum angle of " << _max_angle_curvepolygon << "degrees\n";
+      }
     }
     wentgood = true;
   }

--- a/src/Map3d.cpp
+++ b/src/Map3d.cpp
@@ -53,11 +53,11 @@ Map3d::Map3d() {
   _threshold_jump_edges = 50;
   _threshold_bridge_jump_edges = 50;
   _requestedExtent = Box2(Point2(0, 0), Point2(0, 0));
-  _bbox = Box2(Point2(999999, 999999), Point2(-999999, -999999));
-  _minxradius = 999999;
-  _maxxradius = 999999;
-  _minyradius = -999999;
-  _maxyradius = -999999;
+  _bbox = Box2(Point2(9999999, 9999999), Point2(-9999999, -9999999));
+  _minxradius = 9999999;
+  _maxxradius = 9999999;
+  _minyradius = -9999999;
+  _maxyradius = -9999999;
 }
 
 Map3d::~Map3d() {
@@ -1013,6 +1013,13 @@ bool Map3d::extract_and_add_polygon(GDALDataset* dataSource, PolygonFile* file) 
             numSplitMulti++;
             numSplitPoly += numGeom;
           }
+          break;
+        }
+        case wkbCurvePolygon: {
+          OGRCurvePolygon* curve_polygon = geometry->toCurvePolygon();
+          OGRPolygon* polygon = curve_polygon->CurvePolyToPoly(0);
+          f->SetGeometry(polygon);
+          extract_feature(f, layerName, idfield, heightfield, l.second, multiple_heights);
           break;
         }
         default: {

--- a/src/Map3d.h
+++ b/src/Map3d.h
@@ -104,6 +104,7 @@ public:
   void set_threshold_jump_edges(float threshold);
   void set_threshold_bridge_jump_edges(float threshold);
   void set_requested_extent(double xmin, double ymin, double xmax, double ymax);
+  void set_max_angle_curvepolygon(double max_angle);
 
   void add_allowed_las_class(AllowedLASTopo c, int i);
   void add_allowed_las_class_within(AllowedLASTopo c, int i);
@@ -140,6 +141,7 @@ private:
   double      _minyradius;
   double      _maxyradius;
   Box2        _requestedExtent;
+  double      _max_angle_curvepolygon; //-- the largest step in degrees along the arc, zero to use the default setting.
 
   //-- storing the LAS allowed for each TopoFeature
   std::array<std::set<int>,NUM_ALLOWEDLASTOPO> _las_classes_allowed;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -357,6 +357,8 @@ int main(int argc, const char * argv[]) {
       map3d.set_threshold_bridge_jump_edges(n["threshold_jump_edges"].as<float>());
     if (n["stitching"] && n["stitching"].as<std::string>() == "false")
       bStitching = false;
+    if (n["max_angle_curvepolygon"])
+      map3d.set_max_angle_curvepolygon(n["max_angle_curvepolygon"].as<double>());
 
     if (n["extent"]) {
       std::vector<std::string> extent_split = stringsplit(n["extent"].as<std::string>(), ',');
@@ -1161,6 +1163,15 @@ bool validate_yaml(const char* arg, std::set<std::string>& allowedFeatures) {
       if ((s != "true") && (s != "false")) {
         wentgood = false;
         std::cerr << "\tOption 'options.stitching' invalid; must be 'true' or 'false'.\n";
+      }
+    }
+    if (n["max_angle_curvepolygon"]) {
+      try {
+        boost::lexical_cast<double>(n["max_angle_curvepolygon"].as<std::string>());
+      }
+      catch (boost::bad_lexical_cast& e) {
+        wentgood = false;
+        std::cerr << "\tOption 'options.max_angle_curvepolygon' invalid.\n";
       }
     }
     if (n["extent"]) {


### PR DESCRIPTION
Solves #92

It is stroking input geometries by standard value of [OGR library](https://gdal.org/doxygen/classOGRPolygon.html#a7e5a3f9a67e18e045167832c5b8ff850). Maybe we could add parameter to make it configurable from outside.

Other option would be to simply fail with a clean error message describing the problem.